### PR TITLE
Feature/hu 07 desactivar plantilla obsoleta

### DIFF
--- a/app/api/v1/plantilla_router.py
+++ b/app/api/v1/plantilla_router.py
@@ -1,10 +1,9 @@
-# app/api/v1/plantilla_router.py
 from fastapi import APIRouter, Header
 from fastapi.responses import JSONResponse
 from app.domain.plantilla import PlantillaCreate, PlantillaUpdateObligatorios, PlantillaUpdateCategoria
 from app.services.plantilla_service import (
     PlantillaService, DuplicadoException, AutorizacionException,
-    NoEncontradoException, CamposInvalidosException
+    NoEncontradoException, CamposInvalidosException, ConflictoException
 )
 from app.repositories.plantilla_repository import plantilla_repository
 
@@ -58,7 +57,7 @@ def actualizar_campos_obligatorios(
         })
     except AutorizacionException:
         return JSONResponse(status_code=403, content={
-            "message": "Solo el rol Administrador puede consumir este endpoint",
+            "message": "Solo el rol Administrador can consumir este endpoint",
             "data": None,
             "success": False
         })
@@ -102,6 +101,34 @@ def categorizar_plantilla(
     except NoEncontradoException:
         return JSONResponse(status_code=404, content={
             "message": "Plantilla no encontrada",
+            "data": None,
+            "success": False
+        })
+
+
+@router.patch("/{id}/desactivar", status_code=200)
+def desactivar_plantilla(
+    id: int,
+    x_user_role: str = Header(..., description="Simulación del rol del Token")
+):
+    try:
+        resultado = service.desactivar_plantilla_obsoleta(id=id, rol_usuario=x_user_role)
+        return JSONResponse(status_code=200, content=resultado)
+    except AutorizacionException:
+        return JSONResponse(status_code=403, content={
+            "message": "Solo el rol Administrador puede consumir este endpoint",
+            "data": None,
+            "success": False
+        })
+    except NoEncontradoException:
+        return JSONResponse(status_code=404, content={
+            "message": "Plantilla no encontrada",
+            "data": None,
+            "success": False
+        })
+    except ConflictoException:
+        return JSONResponse(status_code=409, content={
+            "message": "La plantilla ya se encuentra inactiva",
             "data": None,
             "success": False
         })

--- a/app/repositories/plantilla_repository.py
+++ b/app/repositories/plantilla_repository.py
@@ -1,4 +1,3 @@
-# app/repositories/plantilla_repository.py
 from app.domain.plantilla import Plantilla
 from typing import Optional, List
 
@@ -11,7 +10,6 @@ class PlantillaRepository:
         return self._datos
 
     def obtener_por_nombre(self, nombre: str) -> Optional[Plantilla]:
-        # Búsqueda ignorando espacios extra y mayúsculas/minúsculas
         nombre_limpio = " ".join(nombre.strip().split()).lower()
         for p in self._datos:
             p_limpio = " ".join(p.nombre.strip().split()).lower()
@@ -26,6 +24,7 @@ class PlantillaRepository:
             secciones=secciones,
             categoria=categoria
         )
+        setattr(nueva, "activo", True)
         self._datos.append(nueva)
         self._siguiente_id += 1
         return nueva
@@ -48,5 +47,10 @@ class PlantillaRepository:
             plantilla.categoria = categoria
         return plantilla
 
+    def desactivar_logico(self, id: int) -> Optional[Plantilla]:
+        plantilla = self.obtener_por_id(id)
+        if plantilla:
+            setattr(plantilla, "activo", False)
+        return plantilla
+
 plantilla_repository = PlantillaRepository()
-    

--- a/app/services/plantilla_service.py
+++ b/app/services/plantilla_service.py
@@ -1,4 +1,3 @@
-# app/services/plantilla_service.py
 from typing import List
 from app.domain.plantilla import PlantillaCreate
 from app.repositories.plantilla_repository import PlantillaRepository
@@ -15,61 +14,73 @@ class NoEncontradoException(Exception):
 class CamposInvalidosException(Exception):
     pass
 
+class ConflictoException(Exception):
+    pass
+
 class PlantillaService:
-
-    def actualizar_campos_obligatorios(self, id: int, campos: List[str], rol_usuario: str):
-        # 1. Validar rol
-        if rol_usuario != "Administrador":
-            raise AutorizacionException("Solo el rol Administrador puede consumir este endpoint")
-
-        # 2. Validar que la plantilla exista
-        plantilla = self.repo.obtener_por_id(id)
-        if not plantilla:
-            raise NoEncontradoException("Plantilla no encontrada")
-
-        # 3. Validar que los campos obligatorios existan en las secciones
-        secciones_validas = set(plantilla.secciones)
-        for campo in campos:
-            if campo not in secciones_validas:
-                raise CamposInvalidosException("Los campos enviados no existen en la plantilla")
-
-        # Guardar cambios
-        return self.repo.actualizar_campos(id, campos)
-
 
     def __init__(self, repo: PlantillaRepository):
         self.repo = repo
 
     def crear_plantilla(self, datos: PlantillaCreate, rol_usuario: str):
-        # Criterio de Aceptación: Validar rol Administrador
         if rol_usuario != "Administrador":
             raise AutorizacionException("Solo el rol Administrador puede consumir este endpoint")
 
-        # Criterio de Aceptación: Validar unicidad del nombre
         existente = self.repo.obtener_por_nombre(datos.nombre)
         if existente:
             raise DuplicadoException("Ya existe una plantilla con ese nombre")
 
-        # Guardar si todo está OK
         return self.repo.crear(
             nombre=datos.nombre,
             secciones=datos.secciones,
             categoria=datos.categoria
         )
-    
-    # app/services/plantilla_service.py
 
-    def actualizar_categoria_plantilla(self, id: int, categoria: str, rol_usuario: str):
-        # 1. Validar permisos
+    def actualizar_campos_obligatorios(self, id: int, campos: List[str], rol_usuario: str):
         if rol_usuario != "Administrador":
             raise AutorizacionException("Solo el rol Administrador puede consumir este endpoint")
 
-        # 2. Buscar la plantilla
         plantilla = self.repo.obtener_por_id(id)
-        
-        # 3. Validar si existe (Caso 3 de tus pruebas)
         if not plantilla:
             raise NoEncontradoException("Plantilla no encontrada")
 
-        # 4. Actualizar y retornar
+        secciones_validas = set(plantilla.secciones)
+        for campo in campos:
+            if campo not in secciones_validas:
+                raise CamposInvalidosException("Los campos enviados no existen en la plantilla")
+
+        return self.repo.actualizar_campos(id, campos)
+
+    def actualizar_categoria_plantilla(self, id: int, categoria: str, rol_usuario: str):
+        if rol_usuario != "Administrador":
+            raise AutorizacionException("Solo el rol Administrador puede consumir este endpoint")
+
+        plantilla = self.repo.obtener_por_id(id)
+        
+        if not plantilla:
+            raise NoEncontradoException("Plantilla no encontrada")
+
         return self.repo.actualizar_categoria(id, categoria)
+
+    def desactivar_plantilla_obsoleta(self, id: int, rol_usuario: str):
+        if rol_usuario != "Administrador":
+            raise AutorizacionException("Solo el rol Administrador puede consumir este endpoint")
+
+        plantilla = self.repo.obtener_por_id(id)
+        if not plantilla:
+            raise NoEncontradoException("Plantilla no encontrada")
+
+        is_active = getattr(plantilla, "activo", True)
+        if not is_active:
+            raise ConflictoException("La plantilla ya se encuentra inactiva")
+
+        self.repo.desactivar_logico(id)
+
+        return {
+            "mensaje": "Plantilla desactivada correctamente",
+            "data": {
+                "id": id,
+                "estado": "inactivo"
+            },
+            "success": True
+        }


### PR DESCRIPTION
## 📝 Descripción

Se implementa la funcionalidad correspondiente a la **HU-07: Desactivar Plantilla Obsoleta**, permitiendo realizar un borrado lógico (Soft Delete) de plantillas del sistema. El desarrollo se acopló por completo a la nueva arquitectura y carpeta `app/` introducida por el equipo, manteniendo el estándar de manejo de excepciones y validación de roles.

## 🛠️ Cambios Realizados

- **Repository (`app/repositories/plantilla_repository.py`):** Se añade el método `desactivar_logico` para mutar el atributo interno `activo` del objeto de plantilla a `False`.
- **Service (`app/services/plantilla_service.py`):** Se crea el método `desactivar_plantilla_obsoleta` con validaciones para el rol "Administrador", existencia de la plantilla y control de estados duplicados (lanza `ConflictoException` si ya estaba inactiva).
- **Router (`app/api/v1/plantilla_router.py`):** Se expone el endpoint `PATCH /{id}/desactivar` capturando y mapeando las excepciones a los códigos HTTP correctos (200, 403, 404, 409).

## 🧪 Casos para Pruebas (QA / Testing)

Probar el endpoint `PATCH /api/v1/plantillas/{id}/desactivar` simulando el token en la cabecera con `X-User-Role`:

1. **Flujo Exitoso (200 OK):** Usar un ID existente y enviar cabecera `X-User-Role: Administrador`. Debe retornar `success: true` y el estado en "inactivo".
2. **Error de Permisos (403 Forbidden):** Enviar cualquier rol diferente a `Administrador` (ej. `usuario`). Debe restringir el acceso.
3. **Error No Encontrado (404 Not Found):** Probar con un ID que no exista en el sistema.
4. **Error de Conflicto (409 Conflict):** Intentar desactivar por segunda vez una plantilla que ya se encuentra inactiva.